### PR TITLE
Fix Docker and API config

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@
 ## Start
 
 1. Kopiere die Datei `.env.example` nach `.env` und passe die Werte bei Bedarf an (Standardwerte funktionieren im Docker Compose)
-2. Im Projektordner: docker compose up --build (verwendet `docker-compose.yml`)
-3. Frontend läuft auf [http://localhost:3000](http://localhost:3000)  
-Backend auf [http://localhost:8000](http://localhost:8000)
+2. Im Projektordner: `docker compose up --build` (verwendet `docker-compose.yml`)
+3. Frontend läuft auf [http://localhost:3000](http://localhost:3000)
+   Backend auf [http://localhost:8000](http://localhost:8000)
+
+Die Container können auch bequem über Portainer erstellt werden. Die
+Dockerfiles erwarten die Umgebungsvariable `REACT_APP_API_URL`, welche
+standardmäßig im Compose-Setup auf `http://backend:8000` gesetzt ist.

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -5,7 +5,7 @@ FROM python:3.11-slim
 WORKDIR /app
 
 # Installiere Python-Abhängigkeiten
-COPY ./app/requirements.txt /app/requirements.txt
+COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
 # Kopiere den Backend-Code

--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -1,7 +1,11 @@
 from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
+import os
 
-SQLALCHEMY_DATABASE_URL = "postgresql://materialuser:materialpass@db:5432/materialdb"
+SQLALCHEMY_DATABASE_URL = os.getenv(
+    "DATABASE_URL",
+    "postgresql://materialuser:materialpass@db:5432/materialdb",
+)
 
 engine = create_engine(SQLALCHEMY_DATABASE_URL)
 SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,10 @@ services:
       - db
 
   frontend:
-    build: ./frontend
+    build:
+      context: ./frontend
+      args:
+        - REACT_APP_API_URL=http://backend:8000
     ports:
       - "3000:3000"
     depends_on:

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -4,9 +4,12 @@ FROM node:20
 
 WORKDIR /app
 
+# Set build-time environment variable for API URL
+ARG REACT_APP_API_URL=http://backend:8000
+ENV REACT_APP_API_URL=$REACT_APP_API_URL
+
 # Installiere Abhängigkeiten
 COPY package.json ./
-COPY package-lock.json ./
 RUN npm install
 
 # Kopiere den restlichen Frontend-Code

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -15,5 +15,6 @@
   "scripts": {
     "start": "react-scripts start",
     "build": "react-scripts build"
-  }
+  },
+  "proxy": "http://backend:8000"
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -1,0 +1,7 @@
+import axios from "axios";
+
+const api = axios.create({
+  baseURL: process.env.REACT_APP_API_URL || "",
+});
+
+export default api;

--- a/frontend/src/components/MaterialSupplierMapping.tsx
+++ b/frontend/src/components/MaterialSupplierMapping.tsx
@@ -1,6 +1,6 @@
 // Basisgerüst für die Material-Lieferant-Mapping Tabelle
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 
 type Mapping = {
   id: number;
@@ -15,9 +15,10 @@ const MaterialSupplierMapping: React.FC = () => {
   const [mappings, setMappings] = useState<Mapping[]>([]);
 
   useEffect(() => {
-    axios.get("/api/material_lieferant")
-      .then(res => setMappings(res.data))
-      .catch(err => console.error(err));
+    api
+      .get("/material_lieferant")
+      .then((res) => setMappings(res.data))
+      .catch((err) => console.error(err));
   }, []);
 
   return (

--- a/frontend/src/components/MaterialTable.tsx
+++ b/frontend/src/components/MaterialTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 
 type Material = {
   id: number;
@@ -13,9 +13,10 @@ const MaterialTable: React.FC = () => {
   const [materialien, setMaterialien] = useState<Material[]>([]);
 
   useEffect(() => {
-    axios.get("/api/materialien")
-      .then(res => setMaterialien(res.data))
-      .catch(err => console.error(err));
+    api
+      .get("/materialien")
+      .then((res) => setMaterialien(res.data))
+      .catch((err) => console.error(err));
   }, []);
 
   return (

--- a/frontend/src/components/PriceHistory.tsx
+++ b/frontend/src/components/PriceHistory.tsx
@@ -1,6 +1,6 @@
 // Preis-Historie-Komponente (für ein Material-Lieferant-Mapping)
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 
 type Preis = {
   id: number;
@@ -16,9 +16,10 @@ const PriceHistory: React.FC<{ materialLieferantId: number }> = ({ materialLiefe
   const [preise, setPreise] = useState<Preis[]>([]);
 
   useEffect(() => {
-    axios.get(`/api/preise?material_lieferant_id=${materialLieferantId}`)
-      .then(res => setPreise(res.data))
-      .catch(err => console.error(err));
+    api
+      .get(`/preise?material_lieferant_id=${materialLieferantId}`)
+      .then((res) => setPreise(res.data))
+      .catch((err) => console.error(err));
   }, [materialLieferantId]);
 
   return (

--- a/frontend/src/components/SupplierTable.tsx
+++ b/frontend/src/components/SupplierTable.tsx
@@ -1,5 +1,5 @@
 import React, { useEffect, useState } from "react";
-import axios from "axios";
+import api from "../api";
 
 type Supplier = {
   id: number;
@@ -11,9 +11,10 @@ const SupplierTable: React.FC = () => {
   const [lieferanten, setLieferanten] = useState<Supplier[]>([]);
 
   useEffect(() => {
-    axios.get("/api/lieferanten")
-      .then(res => setLieferanten(res.data))
-      .catch(err => console.error(err));
+    api
+      .get("/lieferanten")
+      .then((res) => setLieferanten(res.data))
+      .catch((err) => console.error(err));
   }, []);
 
   return (


### PR DESCRIPTION
## Summary
- fix backend Dockerfile path to requirements.txt
- read DATABASE_URL from environment
- allow customizing API URL during front-end build
- add axios wrapper and update front-end to use it
- set build arg for API URL in docker-compose
- document Portainer deployment

## Testing
- `pytest`
- `npm run build` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_68879038df848330b9849d47e9836a47