### PR TITLE
Add react-scripts dev dependency

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,7 +10,8 @@
   },
   "devDependencies": {
     "@types/react": "^18.0.0",
-    "@types/react-dom": "^18.0.0"
+    "@types/react-dom": "^18.0.0",
+    "react-scripts": "^5.0.1"
   },
   "scripts": {
     "start": "react-scripts start",


### PR DESCRIPTION
## Summary
- add `react-scripts` to `devDependencies`

## Testing
- `npm install` *(fails: 403 Forbidden - registry.npmjs.org)*
- `npm install --package-lock-only` *(fails: 403 Forbidden - registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_688796bd54288330964c5690ee7753bd