### PR TITLE
Update uvicorn path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -15,4 +15,4 @@ COPY ./app /app
 EXPOSE 8000
 
 # Starte die FastAPI-App mit Uvicorn
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8000"]


### PR DESCRIPTION
## Summary
- adjust backend Dockerfile so uvicorn runs `app.main:app`

## Testing
- `docker --version` *(fails: command not found)*
- `apt-get update` *(fails due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6887ce715f54833081b35ae8b00da4b3