### PR TITLE
Fix backend Dockerfile app path

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -8,8 +8,8 @@ WORKDIR /app
 COPY requirements.txt /app/requirements.txt
 RUN pip install --no-cache-dir -r /app/requirements.txt
 
-# Kopiere den Backend-Code
-COPY ./app /app
+# Kopiere den Backend-Code samt Ordner
+COPY ./app /app/app
 
 # Exponiere Port (optional, für Info)
 EXPOSE 8000


### PR DESCRIPTION
## Summary
- keep the `app` package when building the backend Docker image

## Testing
- `docker --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68888ca859688330969de153ba1a1e93